### PR TITLE
refactor: springdoc-openapi-starter-webmvc-ui version from 2.2.0 to 2.7.0

### DIFF
--- a/com.fn.ai.auth/build.gradle
+++ b/com.fn.ai.auth/build.gradle
@@ -28,6 +28,8 @@ ext {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
     // JWT
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/com.fn.ai.common/src/main/java/com/fn/ai/common/exception/GlobalExceptionHandler.java
+++ b/com.fn.ai.common/src/main/java/com/fn/ai/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.fn.ai.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(BaseException.class)
+  public ResponseEntity<?> handleBaseException(BaseException e){
+    return ResponseEntity.status(e.getStatus()).body(e.getMessage());
+  }
+}

--- a/com.fn.ai.company/build.gradle
+++ b/com.fn.ai.company/build.gradle
@@ -28,14 +28,13 @@ ext {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// QueryDSL JPA 관련 의존성
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
-
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
 	implementation project(':common')
 	implementation 'org.apache.commons:commons-lang3:3.12.0'

--- a/com.fn.ai.delivery/build.gradle
+++ b/com.fn.ai.delivery/build.gradle
@@ -28,7 +28,7 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/com.fn.ai.gateway/build.gradle
+++ b/com.fn.ai.gateway/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webflux-ui', version: '2.2.0'
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webflux-ui', version: '2.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/com.fn.ai.hub/build.gradle
+++ b/com.fn.ai.hub/build.gradle
@@ -28,12 +28,13 @@ ext {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	// QueryDSL JPA 관련 의존성
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation project(':common')
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/com.fn.ai.notification/build.gradle
+++ b/com.fn.ai.notification/build.gradle
@@ -29,7 +29,7 @@ ext {
 
 dependencies {
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation project(':common')
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/com.fn.ai.order/build.gradle
+++ b/com.fn.ai.order/build.gradle
@@ -29,7 +29,7 @@ ext {
 
 dependencies {
     implementation project(':common')
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/com.fn.ai.product/build.gradle
+++ b/com.fn.ai.product/build.gradle
@@ -29,7 +29,7 @@ ext {
 
 dependencies {
     implementation project(':common')
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/com.fn.ai.user/build.gradle
+++ b/com.fn.ai.user/build.gradle
@@ -28,7 +28,7 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation project(':common')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'


### PR DESCRIPTION
## #️⃣ Issue Number
close #74 

## 📄 설명

- 스웨거를 적용 후 `ControllerAdviceBean`을 찾지 못하는 이슈 발생
  - 이 후,  해결 방법으로는 `ControllerAdvice` 자체를 제거하는 것
  - `BaseException`을 사용하지 못했음.
- `BaseException`을 사용하지 못하는 것은 상당히 불편했고, 이를 해결하고자함.

springdoc-openapi-starter-webmvc-ui 의 버전을 최신으로 변경함으로써 해결

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)




## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
